### PR TITLE
Handle NaN in `aspect-ratio`

### DIFF
--- a/lib/matches.test.ts
+++ b/lib/matches.test.ts
@@ -206,6 +206,10 @@ test("matches aspect-ratio", () => {
   expect(check("(1/100000 < aspect-ratio)")).toBe(true);
   expect(check("(1 < aspect-ratio)")).toBe(true);
   expect(check("(0.5 < aspect-ratio)")).toBe(true);
+  const noSize = { widthPx: 0, heightPx: 0, deviceWidthPx: 0, deviceHeightPx: 0 };
+  expect(check("(aspect-ratio: 1/1)", noSize)).toBe(false);
+  expect(check("(min-aspect-ratio: 1/1)", noSize)).toBe(false);
+  expect(check("(max-aspect-ratio: 1/1)", noSize)).toBe(false);
 });
 
 test("matches color-index", () => {

--- a/lib/matches.ts
+++ b/lib/matches.ts
@@ -504,6 +504,7 @@ export const matches = (
         const max = maxRatio[0] / maxRatio[1];
         const aspectRatio = env.widthPx / env.heightPx;
         if (
+          Number.isNaN(aspectRatio) ||
           aspectRatio < min ||
           aspectRatio > max ||
           (min === aspectRatio && !minInclusive) ||


### PR DESCRIPTION
This fixes https://github.com/tbjgolden/media-query-fns/issues/9

Before | After
-|-
<img width="697" height="376" alt="image" src="https://github.com/user-attachments/assets/bf798a20-2540-4007-898b-c82868433b3f" /> | <img width="274" height="148" alt="image" src="https://github.com/user-attachments/assets/b4f0fc5a-5e92-4142-8787-ef6a5024757c" />

